### PR TITLE
Add zodbupdate decode mapping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Changelog
 - Add Support for Python 3
   [rudaporto, pbauer, icemac, davisagli]
 
+- Add decode mapping for zodbupdate migration to Python 3.
+
+
 1.1.3 - 2010-10-02
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,9 @@ setup(
         'ZODB',
         'Zope2',
     ],
+    entry_points={
+        'zodbupdate.decode': [
+            'decodes = Products.ZopeVersionControl:zodbupdate_decode_dict',
+        ],
+    },
 )

--- a/src/Products/ZopeVersionControl/__init__.py
+++ b/src/Products/ZopeVersionControl/__init__.py
@@ -74,3 +74,8 @@ def registerIcon(filename):
     setattr(info, filename,
             ImageFile('www/%s' % filename, globals())
             )
+
+
+zodbupdate_decode_dict = {
+    'Products.ZopeVersionControl.EventLog LogEntry message': 'binary',
+}


### PR DESCRIPTION
This mapping notates the fact that LogEntry's message attribute should remain as bytes when migrating a ZODB to Python 3 using zodbupdate.