### PR TITLE
setup.py: use 'version', without double underscores.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-__version__ = '3.0.0.dev0'
+version = '3.0.0.dev0'
 
 setup(
     name='Products.ZopeVersionControl',
-    version=__version__,
+    version=version,
     description="Zope Version Control",
     long_description=(open('README.rst').read() + "\n" +
                       open('CHANGES.rst').read()),


### PR DESCRIPTION
Otherwise zest.releaser cannot update the version when releasing:

```
ERROR: We could read a version from setup.py, but could not write it back. See https://zestreleaser.readthedocs.io/en/latest/versions.html for hints.
Traceback (most recent call last):
  File "../../bin/fullrelease", line 73, in <module>
    sys.exit(zest.releaser.fullrelease.main())
  File "/Users/maurits/shared-eggs/cp27m/zest.releaser-6.22.2-py2.7.egg/zest/releaser/fullrelease.py", line 23, in main
    prereleaser.run()
  File "/Users/maurits/shared-eggs/cp27m/zest.releaser-6.22.2-py2.7.egg/zest/releaser/baserelease.py", line 423, in run
    self.execute()
  File "/Users/maurits/shared-eggs/cp27m/zest.releaser-6.22.2-py2.7.egg/zest/releaser/prerelease.py", line 73, in execute
    self._write_version()
  File "/Users/maurits/shared-eggs/cp27m/zest.releaser-6.22.2-py2.7.egg/zest/releaser/baserelease.py", line 352, in _write_version
    self.vcs.version = self.data['new_version']
  File "/Users/maurits/shared-eggs/cp27m/zest.releaser-6.22.2-py2.7.egg/zest/releaser/vcs.py", line 316, in _update_version
    raise RuntimeError("Cannot set version")
RuntimeError: Cannot set version
```

Alternatively, following the [linked documentation](https://zestreleaser.readthedocs.io/en/latest/versions.html), this would work in `setup.cfg`:

```
[zest.releaser]
python-file-with-version = setup.py
```

But then we need to prevent deleting this setting when the config is updated.

The version with double underscores is hardly ever used in the Zope packages.
I cannot see a use for this in `setup.py`, only possibly in `Products/ZopeVersionControl/__init__.py` so you can import it.